### PR TITLE
Specify in README that the students can submit a report with the assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ Mean reference accuracies over 10 random seeds with their standard deviation sho
 
 ### Submission
 
+**Code:**
 You will submit a full code package, with output files, on **Canvas**. This package will be checked by the TAs in the 1-2 weeks 
    after the assignment for its correctness and executability.
+
+**Report (optional):** Your zip file can include a pdf file, named ANDREWID-report.pdf, if (1) you've implemented something else on top of the requirements and further improved accuracy for possible extra points (see "Grading" below), and/or (2) if your best results are with some hyperparameters other than the default, and you want to specify how we should run your code. If you're doing (1), we expect your report should be 1-2 pages, but no more than 3 pages. If you're doing (2), the report can be very brief.
 
 #### Canvas Submission
 


### PR DESCRIPTION
In previous versions of this course, students were told that they could write a report describing what they did (particularly for the A+ grading criterion). I accidentally removed this from the README for this updated repository. This PR brings this information back into the README.